### PR TITLE
userProperties argument to publish

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	paho "github.com/eclipse/paho.golang/paho"
+	"github.com/eclipse/paho.golang/paho"
 	"go.k6.io/k6/metrics"
 )
 
@@ -15,15 +15,29 @@ func (c *client) Publish(
 	message []byte,
 	retain bool,
 	timeout uint,
+	userProperties map[string]string,
 ) error {
 	ctx := context.Background()
 
+	// Add user properties if any were passed in.
+	var properties *paho.PublishProperties
+	if len(userProperties) > 0 {
+		properties = &paho.PublishProperties{}
+	}
+	for k, v := range userProperties {
+		properties.User = append(properties.User, paho.UserProperty{
+			Key:   k,
+			Value: v,
+		})
+	}
+
 	_, publish_error := c.connectionManager.Publish(ctx, &paho.Publish{
-		QoS:     1,
-		Topic:  topic,
-		Payload: message,
+		QoS:        1,
+		Topic:      topic,
+		Payload:    message,
+		Properties: properties,
 	})
-	if (publish_error != nil) {
+	if publish_error != nil {
 		fmt.Println("error publishing message: ", publish_error, " to topic: ", topic, " for message: ", message)
 		return publish_error
 	}


### PR DESCRIPTION
The userProperties argument can be used to pass custom metadata along with the message being published.